### PR TITLE
Replace references to the old protoXEP with ones to XEP-0485

### DIFF
--- a/readme.html
+++ b/readme.html
@@ -37,12 +37,7 @@
 
 <p>
     The Pubsub Server Info plugin provides a way for Openfire to report statistics about itself in a well-known pub-sub
-    node: 'serverinfo'. The data format is defined in <a href="https://xmpp.org/extensions/inbox/xep-pubsub-server-info.html">XEP-xxxx: PubSub Server Info</a>.
-</p>
-<p>
-    Note: at the time of writing, the protocol as implemented by this plugin has not yet been accepted for consideration or approved
-    in any official manner by the XMPP Standards Foundation, and this document is not yet an XMPP Extension Protocol (XEP). This plugin should
-    be considered experimental.
+    node: 'serverinfo'. The data format is defined in <a href="https://xmpp.org/extensions/xep-0485.html">XEP-0485: PubSub Server Info</a>.
 </p>
 
 <h2>Installation</h2>

--- a/readme.md
+++ b/readme.md
@@ -1,11 +1,7 @@
 # Openfire PubSub Server Info Plugin
 
 The PubSub Server Info plugin provides a way for Openfire to report statistics about itself in a well-known pub-sub
-node: 'serverinfo'. The data format is defined in [XEP-xxxx: PubSub Server Info](https://xmpp.org/extensions/inbox/xep-pubsub-server-info.html).
-
-Note: at the time of writing, the protocol as implemented by this plugin has not yet been accepted for consideration or approved 
-in any official manner by the XMPP Standards Foundation, and this document is not yet an XMPP Extension Protocol (XEP). This plugin should
-be considered experimental.
+node: 'serverinfo'. The data format is defined in [XEP-0485: PubSub Server Info](https://xmpp.org/extensions/xep-0485.html).
 
 This plugin is what could be used by applications such as the [XMPP Network Graph](https://xmppnetwork.goodbytes.im)
 

--- a/src/java/org/igniterealtime/openfire/plugin/pubsubserverinfo/PubSubServerInfoPlugin.java
+++ b/src/java/org/igniterealtime/openfire/plugin/pubsubserverinfo/PubSubServerInfoPlugin.java
@@ -43,7 +43,7 @@ import java.util.stream.Collectors;
  * An Openfire plugin that periodically collects server information and publishes it on a pub-sub node.
  *
  * @author Guus der Kinderen
- * @see <a href="https://xmpp.org/extensions/inbox/xep-pubsub-server-info.html">XEP-xxxx: PubSub Server Info</a>
+ * @see <a href="https://xmpp.org/extensions/xep-0485.html">XEP-0485: PubSub Server Info</a>
  */
 public class PubSubServerInfoPlugin implements Plugin
 {


### PR DESCRIPTION
The protoXEP has been accepted by the XSF. Instead of referencing to the XEP submitted to the inbox of the XSF, the project should now reference the XEP itself: https://xmpp.org/extensions/xep-0485.html